### PR TITLE
Timestamp error fix.

### DIFF
--- a/lib/sdk.js
+++ b/lib/sdk.js
@@ -69,7 +69,7 @@ class CDN {
   getUrl(action, method, args) {
     const params = sortObjectKeys(Object.assign({}, this.commonParams, args, {
       Action: action,
-      TimeStamp: (new Date().toISOString()).replace(/\.\d{3}/, ''),
+      Timestamp: (new Date().toISOString()).replace(/\.\d{3}/, ''),
       SignatureNonce: Math.round(Math.random() * 10000),
     }));
 


### PR DESCRIPTION
An error has occurred in the latest version due to an incorrect field.